### PR TITLE
fix to support templateref of toolbar

### DIFF
--- a/src/app/demo/file-upload/file-upload-demo.component.html
+++ b/src/app/demo/file-upload/file-upload-demo.component.html
@@ -15,4 +15,19 @@
                     [previewWidth]="'50px'" uploadParamName="files"
                     uploadUrl="http://localhost:3000/upload"></re-file-upload>
   </section>
+
+  <section>
+    <h4>With Custorm Toolbar:</h4>
+    <re-file-upload [autoUpload]="true" [accept]="'image/*'" uploadParamName="files"
+                    [toolbarTemplate]="toolbarTemplate"
+                    uploadUrl="http://localhost:3000/upload"></re-file-upload>
+    <ng-template #toolbarTemplate let-toolbar="">
+      <button class="btn btn-primary" (click)="toolbar.addNewFile($event)"
+            [disabled]="toolbar.isMoreThanMaxItems()">
+        <i class="glyphicon glyphicon-plus"></i> {{toolbar.chooseButton}}
+      </button>
+    </ng-template>
+  </section>
+
+
 </div>

--- a/src/app/exports/file-upload/file-upload.component.html
+++ b/src/app/exports/file-upload/file-upload.component.html
@@ -1,7 +1,8 @@
+<input #file type="file" (change)="newFileChoose(file)" style="display: none">
+
 <ng-template #defaultToolbarTemplate let-toolbar="">
   <div class="file-upload-toolbar">
-    <input #file type="file" (change)="toolbar.newFileChoose(file)" style="display: none">
-    <button class="btn btn-primary" (click)="toolbar.addNewFile(file, $event)"
+    <button class="btn btn-primary" (click)="toolbar.addNewFile($event)"
             [disabled]="toolbar.isMoreThanMaxItems()">
       <i class="glyphicon glyphicon-plus"></i> {{toolbar.chooseButton}}
     </button>

--- a/src/app/exports/file-upload/file-upload.component.ts
+++ b/src/app/exports/file-upload/file-upload.component.ts
@@ -99,10 +99,10 @@ export class FileUploadComponent implements AfterViewInit {
     }
   }
 
-  addNewFile(fileInput: HTMLInputElement, $event) {
+  addNewFile($event) {
     $event.stopPropagation();
-    fileInput.value = null;
-    fileInput.click(); // simulate file input event
+    this.fileInput.nativeElement.value = null;
+    this.fileInput.nativeElement.click(); // simulate file input event
   }
 
   newFileChoose(fileInput: HTMLInputElement) {


### PR DESCRIPTION
FileUpload 现在在使用 toolbarTemplate 输入的时候会出现错误，原因是 组件是没有办法获取file引用。

```
<input #file type="file" (change)="toolbar.newFileChoose(file)" style="display: none">
```

其实file引用没有在模板中管理，只需要提供给用户选择图片，上传图片等接口方法即可。